### PR TITLE
Fix Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.out
 *.pdf
 *.toc
+build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+.PHONY: build
 build:
-	@pdflatex whitepaper.tex
+	@latexmk -pdf -output-directory=build whitepaper.tex
 
+.PHONY: clean
 clean:
-	@find -E . -regex '.*\.(aux|brf|log|out|pdf|toc)' -delete
+	@rm -rf build


### PR DESCRIPTION
In the current `Makefile`, `build` does not specify dependencies and is not marked `PHONY`, so it doesn't rerun the rule correctly.

Since Makefiles are notoriously difficult to write for latex, let's just use `latexmk` and mark the build rules `PHONY`.