### PR TITLE
Fixed Typo

### DIFF
--- a/whitepaper.tex
+++ b/whitepaper.tex
@@ -118,7 +118,7 @@ The Helium network is built around the following key components:
 
 \section{The Helium DWN}
 
-We introduce the core conmponents of the DWN.
+We introduce the core components of the DWN.
 
 \subsection{Participants}
 


### PR DESCRIPTION
While reading the whitepaper come across with typo which is corrected now.

conmponents -> components